### PR TITLE
Backstack fix

### DIFF
--- a/flipted/app/src/main/AndroidManifest.xml
+++ b/flipted/app/src/main/AndroidManifest.xml
@@ -13,14 +13,14 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme.NoActionBar">
         <activity android:name=".ui.MainActivity">
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity
-            android:name="com.amazonaws.mobileconnectors.cognitoauth.activities.CustomTabsRedirectActivity">
+        <activity android:name="com.amazonaws.mobileconnectors.cognitoauth.activities.CustomTabsRedirectActivity">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 

--- a/flipted/app/src/main/java/edu/calpoly/flipted/ui/MainActivity.kt
+++ b/flipted/app/src/main/java/edu/calpoly/flipted/ui/MainActivity.kt
@@ -10,6 +10,7 @@ import android.view.View
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.commit
 import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModelProvider
@@ -39,17 +40,19 @@ class MainActivity : AppCompatActivity() {
                 setReorderingAllowed(true)
             }
         }
-        val fragmentsStack: Map<String, List<Fragment>> = HashMap<String, List<Fragment>>()
-        val currentSelectedTabTag = ""
 
-        // Used in TabListener to keep currentSelectedTabTag actual.
-        fun setCurrentSelectedTabTag(currentSelectedTabTag: String) {
-            this.currentSelectedTabTag = currentSelectedTabTag
-        }
         val tabLayout = findViewById<TabLayout>(R.id.navbar)
         tabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
-
+            val BACK_STACK_ROOT_TAG = "root_fragment"
             override fun onTabSelected(tab: TabLayout.Tab?) {
+                if (supportFragmentManager.getBackStackEntryCount() > 0) {
+                    val first: FragmentManager.BackStackEntry =
+                        supportFragmentManager.getBackStackEntryAt(0)
+                    supportFragmentManager.popBackStack(
+                        first.getId(),
+                        FragmentManager.POP_BACK_STACK_INCLUSIVE
+                    )
+                }
                 // Handle tab select
                 val targetFragment = when (tab!!.text) {
                     "Home" -> StudentHomeFragment.newInstance()
@@ -62,6 +65,7 @@ class MainActivity : AppCompatActivity() {
                 }
                 supportFragmentManager.commit {
                     replace(R.id.main_view, targetFragment)
+                    addToBackStack(BACK_STACK_ROOT_TAG)
                     setReorderingAllowed(true)
                 }
             }
@@ -110,30 +114,13 @@ class MainActivity : AppCompatActivity() {
                 v.getGlobalVisibleRect(outRect)
                 if (!outRect.contains(event.rawX.toInt(), event.rawY.toInt())) {
                     v.clearFocus()
-                    val imm: InputMethodManager = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+                    val imm: InputMethodManager =
+                        getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
                     imm.hideSoftInputFromWindow(v.getWindowToken(), 0)
                 }
             }
         }
         return super.dispatchTouchEvent(event)
     }
-
-    override fun onBackPressed() {
-        val currentTabFragments: List<Fragment> = fragmentsStack.get(currentSelectedTabTag)
-        if (currentTabFragments.size > 1) {
-            // if it is not first screen then
-            // current screen is closed and removed from Back Stack and shown the previous one
-            val size = currentTabFragments.size
-            val fragment: Fragment = currentTabFragments[size - 2]
-            currentTabFragments.removeAt(size - 1)
-            val fragmentTransaction: FragmentTransaction = supportFragmentManager.beginTransaction()
-            fragmentTransaction.replace(android.R.id.content, fragment)
-            fragmentTransaction.commit()
-        } else {
-            // if it is the first screen then close application will be closed
-            finish()
-        }
-    }
-
 
 }

--- a/flipted/app/src/main/java/edu/calpoly/flipted/ui/MainActivity.kt
+++ b/flipted/app/src/main/java/edu/calpoly/flipted/ui/MainActivity.kt
@@ -24,8 +24,8 @@ import edu.calpoly.flipted.ui.login.LoginFragment
 import edu.calpoly.flipted.ui.login.LoginViewModel
 import edu.calpoly.flipted.ui.marketplace.MarketplaceFragment
 import edu.calpoly.flipted.ui.myProgress.ProgressFragment
-import edu.calpoly.flipted.ui.myProgress.targets.LearningTargetsFragment
 import edu.calpoly.flipted.ui.myTeam.MyTeamFragment
+import java.util.*
 
 
 class MainActivity : AppCompatActivity() {
@@ -39,7 +39,13 @@ class MainActivity : AppCompatActivity() {
                 setReorderingAllowed(true)
             }
         }
+        val fragmentsStack: Map<String, List<Fragment>> = HashMap<String, List<Fragment>>()
+        val currentSelectedTabTag = ""
 
+        // Used in TabListener to keep currentSelectedTabTag actual.
+        fun setCurrentSelectedTabTag(currentSelectedTabTag: String) {
+            this.currentSelectedTabTag = currentSelectedTabTag
+        }
         val tabLayout = findViewById<TabLayout>(R.id.navbar)
         tabLayout.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
 
@@ -110,6 +116,23 @@ class MainActivity : AppCompatActivity() {
             }
         }
         return super.dispatchTouchEvent(event)
+    }
+
+    override fun onBackPressed() {
+        val currentTabFragments: List<Fragment> = fragmentsStack.get(currentSelectedTabTag)
+        if (currentTabFragments.size > 1) {
+            // if it is not first screen then
+            // current screen is closed and removed from Back Stack and shown the previous one
+            val size = currentTabFragments.size
+            val fragment: Fragment = currentTabFragments[size - 2]
+            currentTabFragments.removeAt(size - 1)
+            val fragmentTransaction: FragmentTransaction = supportFragmentManager.beginTransaction()
+            fragmentTransaction.replace(android.R.id.content, fragment)
+            fragmentTransaction.commit()
+        } else {
+            // if it is the first screen then close application will be closed
+            finish()
+        }
     }
 
 


### PR DESCRIPTION
Modified tab selection so there isn't anymore content overlay when the device back button is pressed to navigate back to a tab.

The back button now brings the user back to the "default" of a tab if they press the back button from a different tab. Because trying to go back to a task from the Classes homepage resulted in a null task crash the first time I implemented this, now pressing back brings you back to student home rather than the last page on the previous tab.