### PR TITLE
Missions bl

### DIFF
--- a/flipted/app/src/main/graphql/edu/calpoly/flipted/Missions.graphql
+++ b/flipted/app/src/main/graphql/edu/calpoly/flipted/Missions.graphql
@@ -3,6 +3,7 @@ query GetAllMissionProgress($courseId: String!) {
     mission {
       id
       name
+      description
     }
     progress {
       taskId

--- a/flipted/app/src/main/graphql/edu/calpoly/flipted/Missions.graphql
+++ b/flipted/app/src/main/graphql/edu/calpoly/flipted/Missions.graphql
@@ -15,3 +15,20 @@ query GetAllMissionProgress($courseId: String!) {
     }
   }
 }
+
+query GetMission($missionId:String!) {
+  mission(missionId:$missionId) {
+    id,
+    name,
+    description,
+    missionContent {
+      ...on Task {
+        id,
+        name,
+        instructions,
+        points,
+        dueDate
+      }
+    }
+  }
+}

--- a/flipted/app/src/main/graphql/edu/calpoly/flipted/Missions.graphql
+++ b/flipted/app/src/main/graphql/edu/calpoly/flipted/Missions.graphql
@@ -4,6 +4,15 @@ query GetAllMissionProgress($courseId: String!) {
       id
       name
       description
+      missionContent {
+        ...on Task {
+          id
+          name
+          instructions
+          points
+          dueDate
+        }
+      }
     }
     progress {
       taskId
@@ -12,23 +21,6 @@ query GetAllMissionProgress($courseId: String!) {
         graded
         pointsAwarded
         pointsPossible
-      }
-    }
-  }
-}
-
-query GetMission($missionId:String!) {
-  mission(missionId:$missionId) {
-    id,
-    name,
-    description,
-    missionContent {
-      ...on Task {
-        id,
-        name,
-        instructions,
-        points,
-        dueDate
       }
     }
   }

--- a/flipted/app/src/main/java/edu/calpoly/flipted/backend/ApolloMissionsRepo.kt
+++ b/flipted/app/src/main/java/edu/calpoly/flipted/backend/ApolloMissionsRepo.kt
@@ -4,10 +4,7 @@ import android.util.Log
 import com.apollographql.apollo.coroutines.await
 import com.apollographql.apollo.exception.ApolloException
 import edu.calpoly.flipted.GetAllMissionProgressQuery
-import edu.calpoly.flipted.businesslogic.missions.Mission
-import edu.calpoly.flipted.businesslogic.missions.MissionProgress
-import edu.calpoly.flipted.businesslogic.missions.MissionsRepo
-import edu.calpoly.flipted.businesslogic.missions.TaskStats
+import edu.calpoly.flipted.businesslogic.missions.*
 import edu.calpoly.flipted.businesslogic.tasks.data.TaskSubmissionResult
 
 class ApolloMissionsRepo : ApolloRepo(), MissionsRepo {
@@ -30,12 +27,14 @@ class ApolloMissionsRepo : ApolloRepo(), MissionsRepo {
         return missions.map { missionProgress ->
             MissionProgress(
                     missionProgress.mission.let{ mission ->
-                        Mission(mission.id, mission.name)
+                        Mission(mission.id, mission.name, mission.description, null)
                     },
                     missionProgress.progress.map{ taskStat ->
                         TaskStats(
-                                taskStat.taskId,
-                                taskStat.name,
+                                SparseTask(
+                                    taskStat.taskId,
+                                    taskStat.name
+                                ),
                                 taskStat.submission?.let{ submission ->
                                     TaskSubmissionResult(
                                             taskStat.taskId,

--- a/flipted/app/src/main/java/edu/calpoly/flipted/backend/MockMissionsRepo.kt
+++ b/flipted/app/src/main/java/edu/calpoly/flipted/backend/MockMissionsRepo.kt
@@ -15,33 +15,40 @@ class MockMissionsRepo : MissionsRepo {
             get() = uid.toString()
     }
     private val data = listOf(
-        MissionProgress(
-            Mission("m1", "Mendelian Genetics", "", null),
-            listOf(
-                uids.let{TaskStats(SparseTask(it, "Pea pod phenotypes"), TaskSubmissionResult(it, true, 9, 18, listOf())) },
-                uids.let{TaskStats(SparseTask(it, "Dominant alleles"), TaskSubmissionResult(it, true, 20, 20, listOf()))},
-                uids.let{TaskStats(SparseTask(it, "Recessive alleles"), TaskSubmissionResult(it, true, 2, 14, listOf()))},
-                uids.let{TaskStats(SparseTask(it, "Gene expression"), TaskSubmissionResult(it, true, 57, 100, listOf()))},
-                TaskStats(SparseTask(uids, "Co-dominance"), null)
+        listOf(
+            uids.let{TaskStats(SparseTask(it, "Pea pod phenotypes", "Do da task", 10, null), TaskSubmissionResult(it, true, 9, 18, listOf())) },
+            uids.let{TaskStats(SparseTask(it, "Dominant alleles", "Something", 300, null), TaskSubmissionResult(it, true, 20, 20, listOf()))},
+            uids.let{TaskStats(SparseTask(it, "Recessive alleles", "Bleh", 1, null), TaskSubmissionResult(it, true, 2, 14, listOf()))},
+            uids.let{TaskStats(SparseTask(it, "Gene expression", "none", 20, null), TaskSubmissionResult(it, true, 57, 100, listOf()))},
+            TaskStats(SparseTask(uids, "Co-dominance", "", 4, null), null)
+        ).let{ taskStats ->
+            MissionProgress(
+                Mission("m1", "Mendelian Genetics", "", taskStats.map{it.task}),
+                taskStats
             )
-        ),
-        MissionProgress(
-            Mission("m2", "Genetic Disease", "", null),
-            listOf(
-                uids.let{TaskStats(SparseTask(it, "The Circulatory System"), TaskSubmissionResult(it, true, 8, 10, listOf()))},
-                uids.let{TaskStats(SparseTask(it, "The Structure of Hemoglobin"), TaskSubmissionResult(it, true, 20, 75, listOf()))},
-                uids.let{TaskStats(SparseTask(it, "Genetic Testing"), TaskSubmissionResult(it, true, 17, 18, listOf()))}
+        },
+        listOf(
+            uids.let{TaskStats(SparseTask(it, "The Circulatory System", "abc", 2, null), TaskSubmissionResult(it, true, 8, 10, listOf()))},
+            uids.let{TaskStats(SparseTask(it, "The Structure of Hemoglobin", "def", 3, null), TaskSubmissionResult(it, true, 20, 75, listOf()))},
+            uids.let{TaskStats(SparseTask(it, "Genetic Testing", "ghi", 4, null), TaskSubmissionResult(it, true, 17, 18, listOf()))}
+        ).let{ taskStats ->
+            MissionProgress(
+                Mission("m2", "Genetic Disease", "", taskStats.map{it.task}),
+                    taskStats
+                )
+        },
+        listOf(
+            TaskStats(SparseTask(uids, "The challenges we face, and how GMOs can help", "jkl", 5, null), null),
+            TaskStats(SparseTask(uids, "What are the different kinds of GMO?", "mno", 6, null), null),
+            TaskStats(SparseTask(uids, "How are GMOs made?", "pqr", 7, null), null),
+            TaskStats(SparseTask(uids, "What are the risks of GMOs?", "stu", 8, null), null)
+        ).let { taskStats ->
+            MissionProgress(
+                Mission("m3",  "GMOs", "", taskStats.map{it.task}),
+                taskStats
             )
-        ),
-        MissionProgress(
-            Mission("m3",  "GMOs", "", null),
-            listOf(
-                TaskStats(SparseTask(uids, "The challenges we face, and how GMOs can help"), null),
-                TaskStats(SparseTask(uids, "What are the different kinds of GMO?"), null),
-                TaskStats(SparseTask(uids, "How are GMOs made?"), null),
-                TaskStats(SparseTask(uids, "What are the risks of GMOs?"), null)
-            )
-        )
+        }
+
     )
 
     override suspend fun getAllMissionProgress(courseId: String): List<MissionProgress> {

--- a/flipted/app/src/main/java/edu/calpoly/flipted/backend/MockMissionsRepo.kt
+++ b/flipted/app/src/main/java/edu/calpoly/flipted/backend/MockMissionsRepo.kt
@@ -1,9 +1,6 @@
 package edu.calpoly.flipted.backend
 
-import edu.calpoly.flipted.businesslogic.missions.Mission
-import edu.calpoly.flipted.businesslogic.missions.MissionProgress
-import edu.calpoly.flipted.businesslogic.missions.MissionsRepo
-import edu.calpoly.flipted.businesslogic.missions.TaskStats
+import edu.calpoly.flipted.businesslogic.missions.*
 import edu.calpoly.flipted.businesslogic.tasks.data.TaskSubmissionResult
 import kotlinx.coroutines.delay
 
@@ -19,30 +16,30 @@ class MockMissionsRepo : MissionsRepo {
     }
     private val data = listOf(
         MissionProgress(
-            Mission("m1", "Mendelian Genetics"),
+            Mission("m1", "Mendelian Genetics", "", null),
             listOf(
-                uids.let{TaskStats(it, "Pea pod phenotypes", TaskSubmissionResult(it, true, 9, 18, listOf()))},
-                uids.let{TaskStats(it, "Dominant alleles", TaskSubmissionResult(it, true, 20, 20, listOf()))},
-                uids.let{TaskStats(it, "Recessive alleles", TaskSubmissionResult(it, true, 2, 14, listOf()))},
-                uids.let{TaskStats(it, "Gene expression", TaskSubmissionResult(it, true, 57, 100, listOf()))},
-                TaskStats(uids, "Co-dominance", null)
+                uids.let{TaskStats(SparseTask(it, "Pea pod phenotypes"), TaskSubmissionResult(it, true, 9, 18, listOf())) },
+                uids.let{TaskStats(SparseTask(it, "Dominant alleles"), TaskSubmissionResult(it, true, 20, 20, listOf()))},
+                uids.let{TaskStats(SparseTask(it, "Recessive alleles"), TaskSubmissionResult(it, true, 2, 14, listOf()))},
+                uids.let{TaskStats(SparseTask(it, "Gene expression"), TaskSubmissionResult(it, true, 57, 100, listOf()))},
+                TaskStats(SparseTask(uids, "Co-dominance"), null)
             )
         ),
         MissionProgress(
-            Mission("m2", "Genetic Disease"),
+            Mission("m2", "Genetic Disease", "", null),
             listOf(
-                uids.let{TaskStats(it, "The Circulatory System", TaskSubmissionResult(it, true, 8, 10, listOf()))},
-                uids.let{TaskStats(it, "The Structure of Hemoglobin", TaskSubmissionResult(it, true, 20, 75, listOf()))},
-                uids.let{TaskStats(it, "Genetic Testing", TaskSubmissionResult(it, true, 17, 18, listOf()))}
+                uids.let{TaskStats(SparseTask(it, "The Circulatory System"), TaskSubmissionResult(it, true, 8, 10, listOf()))},
+                uids.let{TaskStats(SparseTask(it, "The Structure of Hemoglobin"), TaskSubmissionResult(it, true, 20, 75, listOf()))},
+                uids.let{TaskStats(SparseTask(it, "Genetic Testing"), TaskSubmissionResult(it, true, 17, 18, listOf()))}
             )
         ),
         MissionProgress(
-            Mission("m3",  "GMOs"),
+            Mission("m3",  "GMOs", "", null),
             listOf(
-                TaskStats(uids, "The challenges we face, and how GMOs can help", null),
-                TaskStats(uids, "What are the different kinds of GMO?", null),
-                TaskStats(uids, "How are GMOs made?", null),
-                TaskStats(uids, "What are the risks of GMOs?", null)
+                TaskStats(SparseTask(uids, "The challenges we face, and how GMOs can help"), null),
+                TaskStats(SparseTask(uids, "What are the different kinds of GMO?"), null),
+                TaskStats(SparseTask(uids, "How are GMOs made?"), null),
+                TaskStats(SparseTask(uids, "What are the risks of GMOs?"), null)
             )
         )
     )

--- a/flipted/app/src/main/java/edu/calpoly/flipted/businesslogic/missions/MissionProgressDataObjects.kt
+++ b/flipted/app/src/main/java/edu/calpoly/flipted/businesslogic/missions/MissionProgressDataObjects.kt
@@ -1,15 +1,25 @@
 package edu.calpoly.flipted.businesslogic.missions
 
 import edu.calpoly.flipted.businesslogic.tasks.data.TaskSubmissionResult
+import java.util.*
 
 data class Mission(
     val uid: String,
-    val name: String
+    val name: String,
+    val description: String,
+    val content: List<SparseTask>?
+)
+
+data class SparseTask(
+    val id: String,
+    val name: String,
+    val instructions: String? = null,
+    val points: Int? = null,
+    val dueDate: Date? = null
 )
 
 data class TaskStats(
-    val taskId: String,
-    val name: String,
+    val task: SparseTask,
     val submission: TaskSubmissionResult?
 )
 

--- a/flipted/app/src/main/java/edu/calpoly/flipted/businesslogic/missions/MissionProgressDataObjects.kt
+++ b/flipted/app/src/main/java/edu/calpoly/flipted/businesslogic/missions/MissionProgressDataObjects.kt
@@ -7,15 +7,15 @@ data class Mission(
     val uid: String,
     val name: String,
     val description: String,
-    val content: List<SparseTask>?
+    val content: List<SparseTask>
 )
 
 data class SparseTask(
     val id: String,
     val name: String,
-    val instructions: String? = null,
-    val points: Int? = null,
-    val dueDate: Date? = null
+    val instructions: String,
+    val points: Int,
+    val dueDate: Date?
 )
 
 data class TaskStats(

--- a/flipted/app/src/main/java/edu/calpoly/flipted/ui/myProgress/missionDetails/CustomListAdapterTask.kt
+++ b/flipted/app/src/main/java/edu/calpoly/flipted/ui/myProgress/missionDetails/CustomListAdapterTask.kt
@@ -35,7 +35,7 @@ class CustomListAdapterTask(
     }
 
     override fun getItemId(position: Int): Long {
-        return uidMap.getStableId(data[position].taskId)
+        return uidMap.getStableId(data[position].task.id)
     }
 
     override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View {
@@ -46,7 +46,7 @@ class CustomListAdapterTask(
         val taskProgressText: TextView = fillInView.findViewById(R.id.mission_task_percent)
         val data = getItem(position)
 
-        taskName.text = data.name
+        taskName.text = data.task.name
         if(data.submission != null){
             val progressVal = (data.submission.pointsAwarded.toFloat() /data.submission.pointsPossible.toFloat())*100
             if (progressVal <= 50){

--- a/flipted/app/src/main/java/edu/calpoly/flipted/ui/myProgress/missionDetails/MissionTaskViewModel.kt
+++ b/flipted/app/src/main/java/edu/calpoly/flipted/ui/myProgress/missionDetails/MissionTaskViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import edu.calpoly.flipted.backend.ApolloMissionsRepo
-import edu.calpoly.flipted.backend.MockMissionsRepo
 import edu.calpoly.flipted.businesslogic.missions.GetAllMissionProgress
 import edu.calpoly.flipted.businesslogic.missions.MissionProgress
 


### PR DESCRIPTION
To support the missions UI, the `mission(...)` query is insufficient. This is because we need some way of showing results for submitted tasks, but the `mission(...)` query only returns information about the mission and does not include `TaskSubmissionResult` objects.

There are three ways this can be addressed:
1. Use the `retrieveTaskSubmission(...)` for every task in the mission.
2. Ask the backend team to develop a new `getSingleMissionProgress(...)` query that takes a missionId and returns a MissionProgress for that missionId
3. Use `getAllMissionProgress(...)` query to get all the missions, and cache the results in the ViewModel. Arrange the cached data in a hash table, with the missionId as the key. Then, when the Mission page is opened, look up the desired mission in the hash table.

I decided on option 3 for the following reasons:
- It allows code reuse between the "Mission" page and the "Mission Progress" page.
- It reduces the loading time when opening a mission page since the data is only retrieved once and cached
- Unlike option 1, option 3 does not require repeated queries to the backend
- Unlike option 2, option 3 does not require developing a new backend query
