### PR TITLE
Dependency injection in view models

### DIFF
--- a/flipted/app/src/main/java/edu/calpoly/flipted/ui/DIViewModelFactory.kt
+++ b/flipted/app/src/main/java/edu/calpoly/flipted/ui/DIViewModelFactory.kt
@@ -2,6 +2,10 @@ package edu.calpoly.flipted.ui
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import edu.calpoly.flipted.backend.ApolloGoalsRepo
+import edu.calpoly.flipted.backend.ApolloLearningTargetsRepo
+import edu.calpoly.flipted.backend.ApolloMissionsRepo
+import edu.calpoly.flipted.backend.ApolloTasksRepo
 import edu.calpoly.flipted.ui.goals.GoalsViewModel
 import edu.calpoly.flipted.ui.goals.edit.EditGoalViewModel
 import edu.calpoly.flipted.ui.login.LoginViewModel
@@ -11,6 +15,13 @@ import edu.calpoly.flipted.ui.myProgress.targets.TargetsViewModel
 import edu.calpoly.flipted.ui.tasks.TaskViewModel
 
 class DIViewModelFactory : ViewModelProvider.Factory {
+    companion object {
+        private val goalsRepo by lazy { ApolloGoalsRepo() }
+        private val missionsRepo by lazy { ApolloMissionsRepo() }
+        private val learningTargetsRepo by lazy { ApolloLearningTargetsRepo() }
+        private val tasksRepo by lazy { ApolloTasksRepo() }
+    }
+
     /**
      * Creates a new instance of the given `Class`.
      *
@@ -22,13 +33,13 @@ class DIViewModelFactory : ViewModelProvider.Factory {
     </T> */
     override fun <T : ViewModel?> create(modelClass: Class<T>): T
         = when (modelClass) {
-            GoalsViewModel::class.java -> GoalsViewModel()
-            EditGoalViewModel::class.java -> EditGoalViewModel()
+            GoalsViewModel::class.java -> GoalsViewModel(goalsRepo)
+            EditGoalViewModel::class.java -> EditGoalViewModel(goalsRepo)
             LoginViewModel::class.java -> LoginViewModel()
-            MissionTaskViewModel::class.java -> MissionTaskViewModel()
-            MissionsViewModel::class.java -> MissionsViewModel()
-            TargetsViewModel::class.java -> TargetsViewModel()
-            TaskViewModel::class.java -> TaskViewModel()
+            MissionTaskViewModel::class.java -> MissionTaskViewModel(missionsRepo)
+            MissionsViewModel::class.java -> MissionsViewModel(missionsRepo, tasksRepo)
+            TargetsViewModel::class.java -> TargetsViewModel(learningTargetsRepo)
+            TaskViewModel::class.java -> TaskViewModel(tasksRepo)
             else -> modelClass.newInstance()
         } as T
 }

--- a/flipted/app/src/main/java/edu/calpoly/flipted/ui/DIViewModelFactory.kt
+++ b/flipted/app/src/main/java/edu/calpoly/flipted/ui/DIViewModelFactory.kt
@@ -1,0 +1,34 @@
+package edu.calpoly.flipted.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import edu.calpoly.flipted.ui.goals.GoalsViewModel
+import edu.calpoly.flipted.ui.goals.edit.EditGoalViewModel
+import edu.calpoly.flipted.ui.login.LoginViewModel
+import edu.calpoly.flipted.ui.myProgress.missionDetails.MissionTaskViewModel
+import edu.calpoly.flipted.ui.myProgress.missions.MissionsViewModel
+import edu.calpoly.flipted.ui.myProgress.targets.TargetsViewModel
+import edu.calpoly.flipted.ui.tasks.TaskViewModel
+
+class DIViewModelFactory : ViewModelProvider.Factory {
+    /**
+     * Creates a new instance of the given `Class`.
+     *
+     *
+     *
+     * @param modelClass a `Class` whose instance is requested
+     * @param <T>        The type parameter for the ViewModel.
+     * @return a newly created ViewModel
+    </T> */
+    override fun <T : ViewModel?> create(modelClass: Class<T>): T
+        = when (modelClass) {
+            GoalsViewModel::class.java -> GoalsViewModel()
+            EditGoalViewModel::class.java -> EditGoalViewModel()
+            LoginViewModel::class.java -> LoginViewModel()
+            MissionTaskViewModel::class.java -> MissionTaskViewModel()
+            MissionsViewModel::class.java -> MissionsViewModel()
+            TargetsViewModel::class.java -> TargetsViewModel()
+            TaskViewModel::class.java -> TaskViewModel()
+            else -> modelClass.newInstance()
+        } as T
+}

--- a/flipted/app/src/main/java/edu/calpoly/flipted/ui/MainActivity.kt
+++ b/flipted/app/src/main/java/edu/calpoly/flipted/ui/MainActivity.kt
@@ -115,6 +115,9 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    override fun getDefaultViewModelProviderFactory(): ViewModelProvider.Factory
+        = DIViewModelFactory()
+
     override fun dispatchTouchEvent(event: MotionEvent): Boolean {
         if (event.action == MotionEvent.ACTION_DOWN) {
             val v = currentFocus

--- a/flipted/app/src/main/java/edu/calpoly/flipted/ui/goals/GoalsViewModel.kt
+++ b/flipted/app/src/main/java/edu/calpoly/flipted/ui/goals/GoalsViewModel.kt
@@ -1,22 +1,18 @@
 package edu.calpoly.flipted.ui.goals
 
-
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import edu.calpoly.flipted.backend.ApolloGoalsRepo
-import edu.calpoly.flipted.backend.MockGoalsRepo
 import edu.calpoly.flipted.businesslogic.goals.*
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-open class GoalsViewModel : ViewModel() {
+class GoalsViewModel(repo: GoalsRepo) : ViewModel() {
     private val _goals : MutableLiveData<List<Goal>> = MutableLiveData()
     val goals : LiveData<List<Goal>>
         get() = _goals
 
-    private val repo = ApolloGoalsRepo()
     private val getAllGoals = GetAllGoals(repo)
     private val editGoal = EditGoal(repo)
 

--- a/flipted/app/src/main/java/edu/calpoly/flipted/ui/goals/edit/EditGoalViewModel.kt
+++ b/flipted/app/src/main/java/edu/calpoly/flipted/ui/goals/edit/EditGoalViewModel.kt
@@ -4,16 +4,13 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import edu.calpoly.flipted.backend.ApolloGoalsRepo
-import edu.calpoly.flipted.backend.MockGoalsRepo
 import edu.calpoly.flipted.businesslogic.goals.*
 import kotlinx.coroutines.launch
 import java.util.*
 
-class EditGoalViewModel : ViewModel() {
+class EditGoalViewModel(repo: GoalsRepo) : ViewModel() {
     private val _goal = MutableLiveData<Goal>()
 
-    private val repo = ApolloGoalsRepo()
     private val getGoal = GetGoalById(repo)
     private val editGoal = EditGoal(repo)
 

--- a/flipted/app/src/main/java/edu/calpoly/flipted/ui/myProgress/missionDetails/MissionTaskViewModel.kt
+++ b/flipted/app/src/main/java/edu/calpoly/flipted/ui/myProgress/missionDetails/MissionTaskViewModel.kt
@@ -4,21 +4,18 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import edu.calpoly.flipted.backend.ApolloMissionsRepo
 import edu.calpoly.flipted.businesslogic.missions.GetAllMissionProgress
 import edu.calpoly.flipted.businesslogic.missions.MissionProgress
-
-
+import edu.calpoly.flipted.businesslogic.missions.MissionsRepo
 import kotlinx.coroutines.launch
 
-open class MissionTaskViewModel : ViewModel() {
+class MissionTaskViewModel(repo: MissionsRepo) : ViewModel() {
 
     private val _allMissions: MutableLiveData<Map<String, MissionProgress>> = MutableLiveData()
 
     val allMissions: LiveData<Map<String, MissionProgress>>
         get() = _allMissions
 
-    private val repo = ApolloMissionsRepo()
     private val getProgress = GetAllMissionProgress(repo)
 
 

--- a/flipted/app/src/main/java/edu/calpoly/flipted/ui/myProgress/missions/MissionsViewModel.kt
+++ b/flipted/app/src/main/java/edu/calpoly/flipted/ui/myProgress/missions/MissionsViewModel.kt
@@ -4,23 +4,22 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import edu.calpoly.flipted.backend.ApolloMissionsRepo
-import edu.calpoly.flipted.backend.ApolloTasksRepo
-import edu.calpoly.flipted.backend.MockMissionsRepo
 import edu.calpoly.flipted.businesslogic.missions.GetAllMissionProgress
 import edu.calpoly.flipted.businesslogic.missions.MissionProgress
+import edu.calpoly.flipted.businesslogic.missions.MissionsRepo
 import edu.calpoly.flipted.businesslogic.missions.TaskStats
 import edu.calpoly.flipted.businesslogic.targets.TaskObjectiveProgress
 import edu.calpoly.flipted.businesslogic.tasks.GetObjectiveProgress
+import edu.calpoly.flipted.businesslogic.tasks.TasksRepo
 import kotlinx.coroutines.launch
 
-class MissionsViewModel : ViewModel() {
+
+class MissionsViewModel(missionsRepo: MissionsRepo, tasksRepo: TasksRepo) : ViewModel() {
     private val _missionsProgress: MutableLiveData<Map<String, MissionProgress>> = MutableLiveData()
     private val _currMissionId: MutableLiveData<String> = MutableLiveData()
     private val _currTaskInfo: MutableLiveData<TaskStats> = MutableLiveData()
     private val _taskObjectives: MutableLiveData<List<TaskObjectiveProgress>> = MutableLiveData()
 
-    private val tasksRepo = ApolloTasksRepo()
     private val getObjectiveProgressUseCase = GetObjectiveProgress(tasksRepo)
 
     val missionsProgress: LiveData<Map<String, MissionProgress>>
@@ -32,8 +31,7 @@ class MissionsViewModel : ViewModel() {
     val taskObjectives: LiveData<List<TaskObjectiveProgress>>
         get() = _taskObjectives
 
-    private val repo = ApolloMissionsRepo()
-    private val getProgress = GetAllMissionProgress(repo)
+    private val getProgress = GetAllMissionProgress(missionsRepo)
 
     fun fetchMissionsProgress() {
         viewModelScope.launch {

--- a/flipted/app/src/main/java/edu/calpoly/flipted/ui/myProgress/targets/TargetsViewModel.kt
+++ b/flipted/app/src/main/java/edu/calpoly/flipted/ui/myProgress/targets/TargetsViewModel.kt
@@ -4,17 +4,14 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import edu.calpoly.flipted.backend.ApolloLearningTargetsRepo
-import edu.calpoly.flipted.backend.MockLearningTargetsRepo
 import edu.calpoly.flipted.businesslogic.targets.GetAllTargetProgress
-import edu.calpoly.flipted.businesslogic.targets.LearningTarget
+import edu.calpoly.flipted.businesslogic.targets.LearningTargetsRepo
 import edu.calpoly.flipted.businesslogic.targets.TargetProgress
 import kotlinx.coroutines.launch
 
-class TargetsViewModel : ViewModel() {
+class TargetsViewModel(repo: LearningTargetsRepo) : ViewModel() {
     private val _allProgress : MutableLiveData<Map<String, TargetProgress>> = MutableLiveData()
 
-    private val repo = ApolloLearningTargetsRepo()
     private val getAllTargetProgressUseCase = GetAllTargetProgress(repo)
 
     val allProgress: LiveData<Map<String, TargetProgress>>

--- a/flipted/app/src/main/java/edu/calpoly/flipted/ui/tasks/TaskViewModel.kt
+++ b/flipted/app/src/main/java/edu/calpoly/flipted/ui/tasks/TaskViewModel.kt
@@ -1,7 +1,6 @@
 package edu.calpoly.flipted.ui.tasks
 
 import androidx.lifecycle.*
-import edu.calpoly.flipted.backend.ApolloTasksRepo
 import edu.calpoly.flipted.businesslogic.quizzes.data.StudentAnswerInput
 import edu.calpoly.flipted.businesslogic.quizzes.data.questions.Question
 import edu.calpoly.flipted.businesslogic.targets.TaskObjectiveProgress
@@ -11,14 +10,13 @@ import edu.calpoly.flipted.businesslogic.tasks.data.blocks.QuizBlock
 import kotlinx.coroutines.launch
 
 
-class TaskViewModel : ViewModel() {
+class TaskViewModel(repo: TasksRepo) : ViewModel() {
     private val _currTask: MutableLiveData<Task> = MutableLiveData()
     private val _currResponse: MutableLiveData<TaskSubmissionResult> = MutableLiveData()
     private val _errorMessage: MutableLiveData<String> = MutableLiveData()
     private val _taskObjectives: MutableLiveData<List<TaskObjectiveProgress>> = MutableLiveData()
     val taskAndResponseValid: MediatorLiveData<Boolean> = MediatorLiveData()
 
-    private val repo = ApolloTasksRepo()
     private val getTaskUseCase = GetTask(repo)
     private val submitTaskUseCase = SubmitTask(repo)
     private val saveTaskProgressUseCase = SaveTaskProgress(repo)


### PR DESCRIPTION
This patch uses the Parameterize Constructor technique from the WELC book to extract repository construction out of the constructors of all view models.

This allows for unit testing view models with mocked repositories since the mocks can now be injected when the view models are constructed.