### PR TITLE
rubric checkboxes fix

### DIFF
--- a/flipted/app/src/main/java/edu/calpoly/flipted/ui/tasks/TaskViewModel.kt
+++ b/flipted/app/src/main/java/edu/calpoly/flipted/ui/tasks/TaskViewModel.kt
@@ -156,11 +156,6 @@ class TaskViewModel : ViewModel() {
         _taskObjectives.value = objectives
     }
 
-    fun addTaskSources() {
-
-    }
-
-
     private val allRequirementsComplete = Transformations.map(requirements) { requirements ->
         requirements.values.fold(true) { acc, requirement ->
             acc && requirement.isComplete

--- a/flipted/app/src/main/java/edu/calpoly/flipted/ui/tasks/rubric/TaskRubricFragment.kt
+++ b/flipted/app/src/main/java/edu/calpoly/flipted/ui/tasks/rubric/TaskRubricFragment.kt
@@ -113,7 +113,9 @@ class TaskRubricFragment : Fragment() {
 
             checkBox.text = data.description
 
-            checkBox.isChecked = data.isComplete
+            if (convertView == null) {
+                checkBox.isChecked = data.isComplete
+            }
 
             checkBox.setOnCheckedChangeListener { buttonView, isChecked ->
                 viewModel.saveRubricRequirement(RubricRequirement(data.description, isChecked, data.uid))


### PR DESCRIPTION
I added a null check in the rubric adapter so that changes in the view model aren't updating the checkboxes "checked" status more than once. Now for long requirement lists like in the Hydrogen Bonding task, things don't uncheck themselves after a few seconds.

I also removed an empty function I accidentally put in the TaskViewModel last sprint.